### PR TITLE
ci: cd.yml 파일 생성 - dev 브랜치에서 ci 성공시 자동 배포

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: cd
+
+on:
+  workflow_run:
+    workflows: ["ci"]           # ← CI 워크플로의 name: 과 동일해야 함
+    types: [completed]
+  workflow_dispatch:            # 수동 실행 허용
+
+concurrency:
+  group: cd-master
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'dev'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to EC2 via SSH
+        uses: appleboy/ssh-action@v1.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DEPLOY_DIR: ${{ secrets.EC2_DEPLOY_DIR }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_SSH_PORT || 22 }}
+          script_stop: true
+          script: |
+            set -euxo pipefail
+
+            # 배포 폴더 결정 및 이동
+            DEPLOY_DIR="${DEPLOY_DIR:-$HOME/wisheasy}"
+            mkdir -p "$DEPLOY_DIR"
+            cd "$DEPLOY_DIR"
+
+            # (프라이빗이면) 로그인
+            if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
+              docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_TOKEN" || true
+            fi
+
+            # 컴포즈 파일 검증 → 풀 → 무중단 재기동
+            docker compose config >/dev/null
+            docker compose pull
+            docker compose up -d --remove-orphans
+
+            # (선택) 이미지 캐시 정리
+            docker image prune -f


### PR DESCRIPTION
- docker-compose 사용 테스트를 위해 간단한 cd.yml 초기 세팅을 해두었습니다.
- 그 이전에 레포지토리 secrets에 DOCKERHUB_USERNAME, DOCKERHUB_TOKEN, EC2_HOST, EC2_USER, EC2_SSH_KEY 추가했습니다.
- 추후에 master와 dev 브랜치를 나누어 도메인을 다르게 연결할 방안이 필요합니다 (개발 / 배포 도메인 분리)