### PR TITLE
ci(docker-compose): web/nginx healthcheck 임시 주석 처리

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -190,19 +190,22 @@ jobs:
                 depends_on:
                   db:
                     condition: service_healthy
-                healthcheck:
-                  test: ["CMD-SHELL", "curl -fsS http://localhost:8000/healthz || exit 1"]
-                  interval: 10s
-                  timeout: 3s
-                  retries: 12
+                # 임시 주석 처리, 백엔드에서 /healthz 엔드포인트 구현 전까지 비활성화
+                # healthcheck:
+                #   test: ["CMD-SHELL", "curl -fsS http://localhost:8000/healthz || exit 1"]
+                #   interval: 10s
+                #   timeout: 3s
+                #   retries: 12
 
               nginx:
                 image: nginx:1.27-alpine
                 container_name: nginx_edge
                 restart: always
                 depends_on:
-                  web:
-                    condition: service_healthy
+                  - web
+                  # 임시 주석 처리, healthcheck 켜놓은 이후로 다시 해제 예정
+                  # web:
+                  #   condition: service_healthy
                 ports:
                   - "80:80"
                   - "443:443"
@@ -210,11 +213,12 @@ jobs:
                   - ./nginx/conf.d:/etc/nginx/conf.d:ro
                   - /etc/letsencrypt:/etc/letsencrypt:ro
                 networks: [appnet]
-                healthcheck:
-                  test: ["CMD-SHELL", "curl -f http://localhost/healthz || exit 1"]
-                  interval: 10s
-                  timeout: 3s
-                  retries: 12
+                # 임시 주석 처리
+                # healthcheck:
+                #   test: ["CMD-SHELL", "curl -f http://localhost/healthz || exit 1"]
+                #   interval: 10s
+                #   timeout: 3s
+                #   retries: 12
 
             networks:
               appnet:


### PR DESCRIPTION
- web 서비스 /healthz 엔드포인트 미구현으로 healthcheck 블록(#27~31) 주석 처리
- nginx 서비스 healthcheck 블록(#47~51) 주석 처리
- depends_on.web.condition: service_healthy → 단순 의존성으로 변경
- 컨테이너가 unhealthy로 종료되지 않도록 배포 안정성 확보
- 추후 백엔드 팀원이 /healthz 구현 시 healthcheck 복원 예정