### PR TITLE
fix(web): 502 에러 디버깅을 위한 gunicorn 전환 및 포트 수정

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -273,6 +273,8 @@ jobs:
                 volumes:
                   - ./staticfiles:/app/staticfiles
                 networks: [appnet]
+                ports:
+                  - "80:8000"
                 depends_on:
                   db:
                     condition: service_healthy

--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -273,8 +273,8 @@ jobs:
                 volumes:
                   - ./staticfiles:/app/staticfiles
                 networks: [appnet]
-                ports:
-                  - "80:8000"
+                expose:
+                  - "8000"
                 depends_on:
                   db:
                     condition: service_healthy

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -13,4 +13,6 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
+# Django는 WSGI 규약을 따르면서,
+# 진입점을 app(fastapi)가 아니라 application이라는 객체로 정해놓음
 application = get_wsgi_application()

--- a/dockerfile
+++ b/dockerfile
@@ -46,7 +46,17 @@ RUN pip install --upgrade pip && \
 # 애플리케이션 소스 전체 복사
 COPY . .
 
-# compose에서 80:8000으로 매핑하는 과정이 있으니 80으로 냅둠
-EXPOSE 80
+# docker-compose 파일에도 포트 8000으로 변경
+EXPOSE 8000
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]
+# uvicorn -> gunicorn
+# server:app -> config.wsgi:application -> Django는 WSGI 규약을 따르면서, APPLICATION이라는 객체로 진입점을 정함.
+# FastAPI는 uvicorn, Django는 기본 WSGI 기반 gunicorn 을 많이 쓴다.
+# "--bind", "0.0.0.0:8000" 컨테이너 내부에서 모든 인터페이스로 8000포트를 리슨
+# 그래야 호스트 / 로드밸런서가 포트 매핑으로 접근할 수 있게 됨.
+# --access-logfile : 도커에서 엑세스 로그를 수집하기 좋게끔
+# --error-logfile : 도커에서 에러 로그를 수집하기 좋게끔
+CMD ["gunicorn", "config.wsgi:application", \
+     "--bind", "0.0.0.0:8000", \
+     "--access-logfile", "-", \
+     "--error-logfile", "-"]


### PR DESCRIPTION
- dockerfile: uvicorn → gunicorn (config.wsgi:application) 실행, EXPOSE 8000 적용
- config/wsgi.py: Django WSGI 진입점(application) 관련 주석 보강
- .github/workflows/cicd_web-db-nginx.yml: 포트 매핑 80:8000으로 수정