### PR TITLE
ci(workflows) nginx: 정적 파일 경로를 STATIC_ROOT와 일치하도록 수정

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -222,7 +222,7 @@ jobs:
               add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
               location /static/ {
-                alias /usr/share/nginx/html/static/;
+                alias /app/staticfiles/;
                 try_files $uri $uri/ =404;
               }
 
@@ -296,7 +296,7 @@ jobs:
                 volumes:
                   - ./nginx/conf.d:/etc/nginx/conf.d:ro
                   - /etc/letsencrypt:/etc/letsencrypt:ro
-                  - ./staticfiles:/usr/share/nginx/html/static:ro 
+                  - ./staticfiles:/app/staticfiles:ro
                 networks: [appnet]
 
             networks:


### PR DESCRIPTION
- Nginx location /static/ 의 alias를 로 변경
- docker-compose nginx 서비스의 볼륨을 로 수정
- Django collectstatic 결과를 Nginx가 직접 서빙 가능하도록 구조 정리
- settings.py / web 은 같은 경로, nginx 는 다른 경로라서 nginx 의 경로 변경