### PR TITLE
fix(settings): NameError 해결 위해 DEBUG 변수를 설정하는 순서를 env 객체 정의 이후로 변경

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -21,9 +21,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # environ 초기화
-env = environ.Env(
-    DEBUG=env.bool("DJANGO_DEBUG", default=False)  # 기본값 False
-)
+env = environ.Env()
+
+DEBUG=env.bool("DJANGO_DEBUG", default=False)  # 기본값 False
+
 
 # .env 파일 로드
 environ.Env.read_env(os.path.join(BASE_DIR, ".env"))


### PR DESCRIPTION
- (에러메시지) NameError: name 'env' is not defined
- env 객체를 정의하기 전에 사용해서 문제 발생
- env 를 정의한 후에 DEBUG 변수 설정하도록 순서 변경