### PR TITLE
chore(deps): add django-allauth, PyJWT, cryptography dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@ fastapi
 uvicorn
 requests
 Django==5.2.6
+django-allauth==65.12.0
 gunicorn
 django-environ
 mysqlclient==2.2.7
+PyJWT==2.8.0
+cryptography==46.0.2


### PR DESCRIPTION
body: 커스텀 유저 모델 구현과 django-allauth 연동을 위해
requirements.txt에 django-allauth==65.12.0, PyJWT==2.8.0, cryptography==46.0.2를 추가함. 서버 환경에 패키지를 미리 설치해 이후 커밋의 코드 참조 시 의존성 오류가 발생하지 않도록 함.