### PR TITLE
ci(workflows): Django Site에 wisheasy.site 도메인  추가

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -421,6 +421,8 @@ jobs:
 
             # (2) Google SocialApp 적용
             sudo docker compose -f "$COMPOSE_FILE" run --rm web sh -lc "
+              echo '[deploy:apply-socialapp] (2/3) Django Site 도메인 업데이트...';
+              python manage.py shell -c \"from django.contrib.sites.models import Site; Site.objects.update_or_create(id=1, defaults={'domain': 'wisheasy.site', 'name': 'wisheasy.site'})\";
               echo '[deploy:apply-socialapp] (2/3) Google SocialApp 적용 시작...';
               python manage.py apply_socialapp || echo '[deploy:apply-socialapp] 이미 SocialApp이 존재합니다.';
               echo '[deploy:apply-socialapp] (2/3) Google SocialApp 적용 완료';


### PR DESCRIPTION
- apply_socialapp 실행 전 django_site 테이블의 domain/name을 wisheasy.site로 자동 설정하도록 수정
- GitHub Actions 로그에 site=wisheasy.site로 표시되도록 개선