### PR TITLE
ci(workflows): Django Site 도메인 업데이트 로직 안정화

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -421,8 +421,9 @@ jobs:
 
             # (2) Google SocialApp 적용
             sudo docker compose -f "$COMPOSE_FILE" run --rm web sh -lc "
+              set -e
               echo '[deploy:apply-socialapp] (2/3) Django Site 도메인 업데이트...';
-              python manage.py shell -c \"from django.contrib.sites.models import Site; Site.objects.update_or_create(id=1, defaults={'domain': 'wisheasy.site', 'name': 'wisheasy.site'})\";
+              python manage.py shell -c \"from django.conf import settings; from django.contrib.sites.models import Site; site,_=Site.objects.get_or_create(id=getattr(settings,'SITE_ID',1)); site.domain='wisheasy.site'; site.name='wisheasy.site'; site.save(); print('[deploy:apply-socialapp] Site domain set to:', site.domain)\";
               echo '[deploy:apply-socialapp] (2/3) Google SocialApp 적용 시작...';
               python manage.py apply_socialapp || echo '[deploy:apply-socialapp] 이미 SocialApp이 존재합니다.';
               echo '[deploy:apply-socialapp] (2/3) Google SocialApp 적용 완료';


### PR DESCRIPTION
- apply_socialapp 실행 전 set -e로 에러 감지 강화
- Django settings.SITE_ID 기반으로 Site 객체 get_or_create
- domain/name을 wisheasy.site로 저장 후 실제 적용 로그 출력
- 배포 로그에 '[deploy:apply-socialapp] Site domain set to:' 표시되도록 개선