### PR TITLE
ci(workflows): 'Invalid HTTP_HOST header' 에러 해결을 위한 DJANGO_EC2_HOSTS …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ GOOGLE_CLIENT_SECRET=
 # Django Site ID
 # settings에도 있지만 관리 편의를 위해 추가 
 SITE_ID=
+
+DJANGO_EC2_HOSTS=00.000.00.00

--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -122,6 +122,8 @@ jobs:
             DJANGO_DEBUG=True
             DJANGO_ALLOWED_HOSTS=*
 
+            DJANGO_EC2_HOSTS=${{ secrets.DJANGO_EC2_HOSTS }}
+            
             DOCKERHUB_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/wisheasy
             IMAGE_TAG=sha-${{ github.sha }}
             

--- a/config/settings.py
+++ b/config/settings.py
@@ -36,6 +36,10 @@ SECRET_KEY = env("SECRET_KEY")
 
 ALLOWED_HOSTS = ["wisheasy.site", "www.wisheasy.site"]
 
+# EC2 추가
+EC2 = env.list("DJANGO_EC2_HOSTS", default=[])
+ALLOWED_HOSTS += EC2
+
 # 신뢰된 오리진 목록 
 CSRF_TRUSTED_ORIGINS = [
     "https://wisheasy.site",


### PR DESCRIPTION
…추가 및 CICD 연계

- cicd.yml의 .env 블록에 DJANGO_EC2_HOSTS 를 secret에 참조하는 라인 추가
- settings.py에서 ALLOWED_HOSTS에 EC2 HOST 추가
- .env.example에 DJANGO_EC2_HOSTS 추가