### PR TITLE
refactor(frontend): JS 내 하드코딩된 URL을 Django 템플릿 방식으로 변경

### DIFF
--- a/apps/common/templates/common/index.html
+++ b/apps/common/templates/common/index.html
@@ -44,10 +44,10 @@
                     로그인
                 </button>
                 {% endif %}
-                <button class="mypage-btn" onclick="showMyPage()">
+                <a class="mypage-btn" href="{% url "accounts:settings" %}">
                     <i class="fas fa-cog"></i>
                     마이페이지
-                </button>
+                </a>
             </div>
 
             <!-- Main Buttons -->

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -9,23 +9,33 @@ function initializeMainPage() {
 }
 
 // Navigation functions
+const appContainer = document.getElementById('wisheasy-app');
+
 function goToRoutePage() {
+    // event.target에서부터 가장 가까운 조상 중에 .route-btn 이라는 클래스를 가진 요소를 찾는다.
+    // 찾아낸 버튼에 loading이라는 CSS 클래스를 추가한다. (로딩 중인 ... 표시)
     const btn = event.target.closest('.route-btn');
     btn.classList.add('loading');
 
-    // Simulate loading delay
+    // 0.5초(500ms)간 기다렸다가 코드를 실행한다.
+    // 사용자가 "아, 내 클릭이 잘 인식되었구나"라고 인지할 시간을 벌어주는 UX 장치
     setTimeout(() => {
-        window.location.href = 'route.html';
+        const routePageUrl = appContainer.dataset.routePageUrl;
+        window.location.href = routePageUrl;
     }, 500);
 }
 
 function goToStationPage() {
+    // event.target에서부터 가장 가까운 조상 중에 .route-btn 이라는 클래스를 가진 요소를 찾는다.
+    // 찾아낸 버튼에 loading이라는 CSS 클래스를 추가한다. (로딩 중인 ... 표시)
     const btn = event.target.closest('.station-btn');
     btn.classList.add('loading');
 
-    // Simulate loading delay
+    // 0.5초(500ms)간 기다렸다가 코드를 실행한다.
+    // 사용자가 "아, 내 클릭이 잘 인식되었구나"라고 인지할 시간을 벌어주는 UX 장치
     setTimeout(() => {
-        window.location.href = 'station.html';
+        const stationPageUrl = appContainer.dataset.stationPageUrl;
+        window.location.href = stationPageUrl;
     }, 500);
 }
 
@@ -49,10 +59,10 @@ function handleGoogleLogin() {
     window.location.href = url;   // ← 실제 allauth 구글 로그인으로 이동
 }
 
-
-function showMyPage() {
-    window.location.href = 'settings.html';
-}
+// a 태그로 대체함
+// function showMyPage() {
+//     window.location.href = 'settings.html';
+// }
 
 // Keyboard navigation
 document.addEventListener('keydown', function(e) {

--- a/static/js/route.js
+++ b/static/js/route.js
@@ -460,11 +460,17 @@ function generateAlternativeRoute() {
 }
 
 // Navigation
+const appContainer = document.getElementById('wisheasy-app');
+
 function goBack() {
-    if (window.history.length > 1) {
+    // 방문 기록이 있으면서, 동시에 외부 페이지를 통해 정상적으로 들어온 경우에만 뒤로가기
+    if (window.history.length > 1 && document.referrer) {
         window.history.back();
-    } else {
-        window.location.href = 'main.html';
+    } 
+    // 그렇지 않다면, 메인 페이지로 이동
+    else {  
+        const mainPageUrl = appContainer.dataset.mainPageUrl;
+        window.location.href = mainPageUrl;
     }
 }
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -76,10 +76,17 @@ function loadPriorityOrder() {
     }
 }
 
+// Navigation
+const appContainer = document.getElementById('wisheasy-app');
+
 function goBack() {
-    if (window.history.length > 1) {
+    // 방문 기록이 있으면서, 동시에 외부 페이지를 통해 정상적으로 들어온 경우에만 뒤로가기
+    if (window.history.length > 1 && document.referrer) {
         window.history.back();
-    } else {
-        window.location.href = 'main.html';
+    } 
+    // 그렇지 않다면, 메인 페이지로 이동
+    else {  
+        const mainPageUrl = appContainer.dataset.mainPageUrl;
+        window.location.href = mainPageUrl;
     }
 }

--- a/static/js/station_info.js
+++ b/static/js/station_info.js
@@ -354,17 +354,25 @@ function showTab(tabName) {
 }
 
 // Navigation
+const appContainer = document.getElementById('wisheasy-app');
+
 function goBack() {
     const stationInfo = document.getElementById('stationInfo');
+    // 역 정보 상세가 화면에 표시된 상태라면, 역 정보 상세를 숨기고 다시 검색 화면으로 이동
     if (stationInfo.style.display === 'block') {
         stationInfo.style.display = 'none';
         document.querySelector('.search-section').style.display = 'block';
         document.getElementById('stationSearch').value = '';
         hideAllResults();
-    } else if (window.history.length > 1) {
+    } 
+    // 검색 화면 상태이고 뒤로 갈 방문 기록이 있다면, 이전 페이지로 이동
+    else if (window.history.length > 1 && document.referrer) {
         window.history.back();
-    } else {
-        window.location.href = 'main.html';
+    } 
+    // 검색 화면 상태인데 뒤로 갈 방문 기록이 없다면, 메인 페이지로 이동
+    else {
+        const mainPageUrl = appContainer.dataset.mainPageUrl;
+        window.location.href = mainPageUrl;
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,13 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
-  {% block content %}{% endblock content %}
+  <div id="wisheasy-app"
+    data-main-page-url="{% url 'common:index' %}"
+    data-route-page-url="{% url 'journeys:route' %}"
+    data-station-page-url="{% url 'stations:station_info' %}"
+  >
+    {% block content %}{% endblock content %}
+  </div>
 
   {% block js %}{% endblock js %}
 </body>


### PR DESCRIPTION
- `base.html`에 중앙 `div`를 두어 Django URL을 `data-*` 속성으로 관리하도록 변경하고, JS 파일들이 이를 참조하도록 수정했습니다.
- 하드코딩된 경로(main.html 등)를 제거하여 유지보수성을 향상시켰습니다.
- 단순 이동 함수는 웹 표준을 준수하는 `<a>` 태그로 대체하여 코드를 간소화했습니다.