### PR TITLE
feat(settings): settings 구조를 base/local/prod로 분리하여 환경 파일 분리

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,3 +1,5 @@
+# config/settings/
+
 """
 Django settings for config project.
 
@@ -16,7 +18,7 @@ from pathlib import Path
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 # Quick-start development settings - unsuitable for production

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,0 +1,16 @@
+# config/settings/local.py
+
+from .base import *
+
+DEBUG = True
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+
+# Database
+# https://docs.djangoproject.com/en/5.2/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,0 +1,40 @@
+# config/settings/prod.py
+
+from .base import *
+import environ
+
+# environ 초기화
+env = environ.Env()
+
+DEBUG=False  # 기본값 False
+
+
+# .env 파일 로드
+environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
+
+# 이제 설정 읽기
+SECRET_KEY = env("SECRET_KEY")
+
+ALLOWED_HOSTS = ["wisheasy.site", "www.wisheasy.site"]
+
+# EC2 추가
+EC2 = env.list("DJANGO_EC2_HOSTS", default=[])
+ALLOWED_HOSTS += EC2
+
+# Database
+# https://docs.djangoproject.com/en/5.2/ref/settings/#databases
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": env.str("MYSQL_DB"),
+        "USER": env.str("MYSQL_USER"),
+        "PASSWORD": env.str("MYSQL_PASSWORD"),
+        "HOST": env.str("MYSQL_HOST", default="localhost"),
+        "PORT": env.int("MYSQL_PORT", default=3306),
+        "OPTIONS": {
+            "charset": "utf8mb4",
+        },
+        "CONN_MAX_AGE": env.int("DB_CONN_MAX_AGE", default=0),
+    }
+}


### PR DESCRIPTION
- 기존 단일 settings.py → 디렉토리 구조로 변경(config/settings/)
- 공통 설정을 base.py로 분리하고 local.py, prod.py가 이를 상속하도록 구성
- 로컬 환경에서는 SQLite, 운영 환경에서는 MySQL을 사용하도록 설정 분리
- DEBUG, ALLOWED_HOSTS, DATABASES 등 환경별 값 명확히 구분