### PR TITLE
design(common): 상단 플래시 메시지 영역 제거

### DIFF
--- a/apps/common/templates/common/index.html
+++ b/apps/common/templates/common/index.html
@@ -11,14 +11,6 @@
 
 {% block content %}
     <div class="app-container">
-        <!-- Flash messages (선택) -->
-        {% if messages %}
-        <ul class="messages">
-            {% for message in messages %}
-            <li class="{{ message.tags }}">{{ message }}</li>
-            {% endfor %}
-        </ul>
-        {% endif %}
 
         <!-- App Header -->
         <header class="app-header">


### PR DESCRIPTION
- common/idex.html에서 Django messages 렌더링 블록 삭제
- 로그인/로그아웃 성공 메시지 상단 노출 중단