### PR TITLE
fix(.yml): internal server error 해결을 위한 DJANGO_SETTINGS_MODULE 환경변수 추가

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -296,6 +296,7 @@ jobs:
                   MYSQL_USER: ${MYSQL_USER}
                   MYSQL_PASSWORD: ${MYSQL_PASSWORD}
                   MYSQL_DB: ${MYSQL_DATABASE}
+                  DJANGO_SETTINGS_MODULE: config.settings.prod
                 volumes:
                   - ./staticfiles:/app/staticfiles
                 networks: [appnet]


### PR DESCRIPTION
- docker-compose.yml의 web 서비스의 env에 DJANGO_SETTINGS_MODULE=config.settings.prod 추가
- gunicorn 프로세스가 올바른 Django 설정 모듈을 읽지 못하던 문제 수정
- Internal Server Error(500) 발생 원인 해결