### PR TITLE
fix(main): 메인 페이지 버튼의 비활성화 상태 초기화 로직 추가

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -11,10 +11,13 @@ function initializeMainPage() {
     window.addEventListener('pageshow', function(event) {
         // event.persisted가 true이면, 페이지가 bfcache에서 복원된 것입니다.
         if (event.persisted) {
-            // 모든 메인 버튼을 찾아서 'loading' 클래스를 제거합니다.
+            // 모든 메인 버튼을 찾습니다.
             const mainButtons = document.querySelectorAll('.main-btn');
             mainButtons.forEach(btn => {
+                // 'loading' 클래스를 제거합니다.
                 btn.classList.remove('loading');
+                // 버튼의 비활성화 속성을 제거합니다.
+                btn.disabled = false;
             });
         }
     });


### PR DESCRIPTION
뒤로가기로 메인 페이지에 돌아왔을 때, 버튼의 disabled 속성을 제거하는 로직을 추가했습니다. 이를 통해 버튼이 시각적으로만 활성화되는 것이 아니라, 실제로도 클릭 가능하도록 문제를 해결했습니다.