### PR TITLE
fix(csv): 'app_data' 볼륨 정의 누락 수정

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -345,6 +345,7 @@ jobs:
 
             volumes:
               mysql_data:
+              app_data:
             EOF
             # ----------/deploy:compose-file---------
 


### PR DESCRIPTION
- web 서비스에서 사용하는 app_data 볼륨이 최상위 volumes 섹션에 정의되지 않아 Docker Compose up 과정에서 Invalid Compose Project 오류가 발생

- cicd_web-db-nginx.yml 파일의 volumes 최상위 블록에 app_data를 추가하여 문제 해결하고자 함