### PR TITLE
feat(journeys/views): PRG + 세션 상태 관리 도입 (주석 정리 포함)

### DIFF
--- a/apps/journeys/views.py
+++ b/apps/journeys/views.py
@@ -1,6 +1,9 @@
-from django.shortcuts import render
-# 뷰 데코레이터(특정 요청만 처리하도록 제한)
+from django.shortcuts import render, redirect
 from django.views.decorators.http import require_http_methods
+from django.contrib import messages
+from django.utils import timezone
+import uuid
+
 from apps.journeys.services.guide import (
     load_graph_from_db,
     load_lines_from_db,
@@ -9,45 +12,163 @@ from apps.journeys.services.guide import (
     build_full_guidance,
 )
 
+# Session namespace for journey progress
+SESSION_KEY = "journey"
 
-# Create your views here.
-# 사용자의 경로 안내 우선 순위를 설정한다.
+
+def _init_session(request, steps, start_station, start_exit, end_station, end_exit):
+    """Initialize journey session state right after route is created."""
+    request.session[SESSION_KEY] = {
+        "id": str(uuid.uuid4()),
+        "created_at": timezone.now().isoformat(),
+        "steps": list(steps) if not isinstance(steps, list) else steps,
+        "idx": 0,
+        "start_station": start_station,
+        "start_exit": start_exit,
+        "end_station": end_station,
+        "end_exit": end_exit,
+    }
+    request.session.modified = True
+
+
+def _get_state(request):
+    """Return current journey session dict or None."""
+    return request.session.get(SESSION_KEY)
+
+
+def _set_idx(request, idx):
+    """Update current step index in session."""
+    s = _get_state(request)
+    if not s:
+        return
+    s["idx"] = idx
+    request.session[SESSION_KEY] = s
+    request.session.modified = True
+
+
 @require_http_methods(["GET", "POST"])
 def route(request):
-    context = {"steps": None}
+    """
+    Single URL handling both:
+      - GET: form or guidance view (depends on session)
+      - POST: navigation (next/prev/restart) or initial route submission
+    Follows PRG: every POST ends with redirect to this view.
+    """
+    # default context (form mode)
+    context = {
+        "mode": "form",
+        "step_text": None,
+        "idx": 0,
+        "count": 0,
+        "has_prev": False,
+        "has_next": False,
+        "start_station": None,
+        "start_exit": None,
+        "end_station": None,
+        "end_exit": None,
+    }
 
+    # POST: navigation or initial submission (always redirect back here)
     if request.method == "POST":
+        action = request.POST.get("action")
+
+        # navigation actions
+        if action in ("next", "prev", "restart"):
+            state = _get_state(request)
+            if not state:
+                messages.error(request, "세션이 만료되었어요. 다시 경로를 생성해 주세요.")
+                return redirect("journeys:route")
+
+            steps = state.get("steps", [])
+            idx = state.get("idx", 0)
+
+            if action == "next":
+                idx = min(idx + 1, max(len(steps) - 1, 0))
+            elif action == "prev":
+                idx = max(idx - 1, 0)
+            elif action == "restart":
+                idx = 0
+
+            _set_idx(request, idx)
+            return redirect("journeys:route")
+
+        # initial submission
         start_station = request.POST.get("start_station", "").strip()
-        start_exit    = request.POST.get("start_exit", "").strip()       # 예: "2번출구"
-        end_station   = request.POST.get("end_station", "").strip()
-        end_exit      = request.POST.get("end_exit", "").strip()         # 예: "4번출구"
+        start_exit = request.POST.get("start_exit", "").strip()
+        end_station = request.POST.get("end_station", "").strip()
+        end_exit = request.POST.get("end_exit", "").strip()
 
-        # 1) Lines → G (DB 기반)
-        lines = load_lines_from_db()
-        G = build_subway_graph(lines)
+        if not start_station or not end_station:
+            messages.error(request, "출발역/도착역은 필수입니다.")
+            return redirect("journeys:route")
 
-        # 2) 유저 입력 → short_path_list
-        short_path_list = get_subway_route(
-            start_station=start_station,
-            start_exit=start_exit,
-            end_station=end_station,
-            end_exit=end_exit,
-            lines=lines,
-            G=G,
+        try:
+            lines = load_lines_from_db()
+            G = build_subway_graph(lines)
+
+            short_path_list = get_subway_route(
+                start_station=start_station,
+                start_exit=start_exit,
+                end_station=end_station,
+                end_exit=end_exit,
+                lines=lines,
+                G=G,
+            )
+
+            if not short_path_list:
+                messages.error(request, "경로를 찾지 못했습니다. 역 이름을 확인해 주세요.")
+                return redirect("journeys:route")
+
+            df_nodes, df_edges = load_graph_from_db()
+            steps = build_full_guidance(df_nodes, df_edges, short_path_list)
+            if not isinstance(steps, list):
+                steps = list(steps)
+
+            _init_session(
+                request,
+                steps=steps,
+                start_station=start_station,
+                start_exit=start_exit,
+                end_station=end_station,
+                end_exit=end_exit,
+            )
+            return redirect("journeys:route")
+
+        except Exception as e:
+            messages.error(request, f"경로 생성 중 오류: {e}")
+            return redirect("journeys:route")
+
+    # GET: optional fresh start, then render form/guide depending on session
+    if request.GET.get("new") == "1":
+        request.session.pop(SESSION_KEY, None)
+        request.session.modified = True
+
+    state = _get_state(request)
+    if state:
+        steps = state.get("steps", [])
+        idx = state.get("idx", 0)
+        count = len(steps)
+
+        context.update(
+            {
+                "mode": "guide",
+                "start_station": state.get("start_station"),
+                "start_exit": state.get("start_exit"),
+                "end_station": state.get("end_station"),
+                "end_exit": state.get("end_exit"),
+                "idx": idx,
+                "count": count,
+                "step_text": steps[idx] if steps else "(안내 없음)",
+                "has_prev": idx > 0,
+                "has_next": idx < (count - 1),
+            }
         )
 
-        # 3) Nodes/Edges(ORM) → DataFrame
-        df_nodes, df_edges = load_graph_from_db()
-
-        # 4) 안내 스텝 생성
-        steps = build_full_guidance(df_nodes, df_edges, short_path_list)
-
-        context.update({
-            "steps": steps,
-            "start_station": start_station,
-            "start_exit": start_exit,
-            "end_station": end_station,
-            "end_exit": end_exit,
-        })
-
     return render(request, "journeys/route.html", context)
+
+
+def leave(request):
+    """Clear journey session and return to home."""
+    request.session.pop(SESSION_KEY, None)
+    request.session.modified = True
+    return redirect("common:index")


### PR DESCRIPTION
POST 요청 이후 redirect 처리로 PRG 패턴 적용 및 세션 상태 관리 추가

- 모든 POST 요청 후 redirect('journeys:route') 적용
- SESSION_KEY=journey, _init_session/_get_state/_set_idx 추가
- route(): form/guide 모드 컨텍스트 분기
- leave(): 세션 정리 후 common:index로 리디렉트