### PR TITLE
fix: requirements.txt 의존성 설치 오류 수정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ mysqlclient==2.2.7
 PyJWT==2.8.0
 cryptography==46.0.2
 pandas
-networkx>=3.3, 
+networkx>=3.3


### PR DESCRIPTION
requirements.txt 파일 내 'networkx' 패키지 버전명 뒤에
불필요한 콤마(,)가 포함되어 'Invalid requirement' 오류가
발생하는 문제를 해결했습니다.