### PR TITLE
refactor(common): 메인 버튼 <a> 태그로 변경 및 관련 스크립트 정리

### DIFF
--- a/apps/common/templates/common/index.html
+++ b/apps/common/templates/common/index.html
@@ -44,10 +44,10 @@
           <span class="btn-text">길찾기</span>
         </a>
 
-        <button class="main-btn station-btn" onclick="goToStationPage()">
+        <a class="main-btn station-btn" href="{% url 'stations:station_info' %}">
           <div class="btn-icon"><i class="fas fa-search"></i></div>
           <span class="btn-text">역 정보</span>
-        </button>
+        </a>
       </div>
     </main>
   </div>

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -118,6 +118,7 @@ body {
     gap: 12px;
     position: relative;
     overflow: hidden;
+    text-decoration: none;
 }
 
 .main-btn:hover {
@@ -186,38 +187,38 @@ body {
     .app-container {
         padding: 16px;
     }
-    
+
     .app-icon {
         width: 70px;
         height: 70px;
     }
-    
+
     .icon-text {
         font-size: 28px;
     }
-    
+
     .app-title {
         font-size: 28px;
     }
-    
+
     .app-subtitle {
         font-size: 14px;
     }
-    
+
     .main-card {
         padding: 20px;
     }
-    
+
     .main-btn {
         padding: 20px;
     }
-    
+
     .btn-icon {
         width: 44px !important;
         height: 44px !important;
         font-size: 18px !important;
     }
-    
+
     .btn-text {
         font-size: 16px;
     }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -23,36 +23,36 @@ function initializeMainPage() {
     });
 }
 
-// Navigation functions
-const appContainer = document.getElementById('wisheasy-app');
+// Navigation functions (a 태그로 대체함)
+// const appContainer = document.getElementById('wisheasy-app');
 
-function goToRoutePage() {
-    // event.target에서부터 가장 가까운 조상 중에 .route-btn 이라는 클래스를 가진 요소를 찾는다.
-    // 찾아낸 버튼에 loading이라는 CSS 클래스를 추가한다. (로딩 중인 ... 표시)
-    const btn = event.target.closest('.route-btn');
-    btn.classList.add('loading');
+// function goToRoutePage() {
+//     // event.target에서부터 가장 가까운 조상 중에 .route-btn 이라는 클래스를 가진 요소를 찾는다.
+//     // 찾아낸 버튼에 loading이라는 CSS 클래스를 추가한다. (로딩 중인 ... 표시)
+//     const btn = event.target.closest('.route-btn');
+//     btn.classList.add('loading');
 
-    // 0.5초(500ms)간 기다렸다가 코드를 실행한다.
-    // 사용자가 "아, 내 클릭이 잘 인식되었구나"라고 인지할 시간을 벌어주는 UX 장치
-    setTimeout(() => {
-        const routePageUrl = appContainer.dataset.routePageUrl;
-        window.location.href = routePageUrl;
-    }, 500);
-}
+//     // 0.5초(500ms)간 기다렸다가 코드를 실행한다.
+//     // 사용자가 "아, 내 클릭이 잘 인식되었구나"라고 인지할 시간을 벌어주는 UX 장치
+//     setTimeout(() => {
+//         const routePageUrl = appContainer.dataset.routePageUrl;
+//         window.location.href = routePageUrl;
+//     }, 500);
+// }
 
-function goToStationPage() {
-    // event.target에서부터 가장 가까운 조상 중에 .route-btn 이라는 클래스를 가진 요소를 찾는다.
-    // 찾아낸 버튼에 loading이라는 CSS 클래스를 추가한다. (로딩 중인 ... 표시)
-    const btn = event.target.closest('.station-btn');
-    btn.classList.add('loading');
+// function goToStationPage() {
+//     // event.target에서부터 가장 가까운 조상 중에 .route-btn 이라는 클래스를 가진 요소를 찾는다.
+//     // 찾아낸 버튼에 loading이라는 CSS 클래스를 추가한다. (로딩 중인 ... 표시)
+//     const btn = event.target.closest('.station-btn');
+//     btn.classList.add('loading');
 
-    // 0.5초(500ms)간 기다렸다가 코드를 실행한다.
-    // 사용자가 "아, 내 클릭이 잘 인식되었구나"라고 인지할 시간을 벌어주는 UX 장치
-    setTimeout(() => {
-        const stationPageUrl = appContainer.dataset.stationPageUrl;
-        window.location.href = stationPageUrl;
-    }, 500);
-}
+//     // 0.5초(500ms)간 기다렸다가 코드를 실행한다.
+//     // 사용자가 "아, 내 클릭이 잘 인식되었구나"라고 인지할 시간을 벌어주는 UX 장치
+//     setTimeout(() => {
+//         const stationPageUrl = appContainer.dataset.stationPageUrl;
+//         window.location.href = stationPageUrl;
+//     }, 500);
+// }
 
 function showLoginModal() {
     const loginModal = document.getElementById('loginModal');


### PR DESCRIPTION
메인 페이지에서 '길찾기', '역 정보' 버튼을 <button onclick=> 방식에서 <a> href= 태그 방식으로 변경했습니다. 페이지 이동 시 불필요한 JS 지연을 제거함으로써 반응성이 향상되었습니다.

- index.html: 메인 버튼 2개(길찾기, 역 정보)를 <button>에서 <a> 태그로 변경합니다.
- index.js: <a> 태그로 변경되면서 불필요해진 goToRoutePage, goToStationPage 함수를 주석 처리합니다.
- index.css: <a> 태그 버튼에 기본으로 적용되는 밑줄 스타일을 제거합니다.