### PR TITLE
fix(journeys): route.html 뒤로가기 버튼 로직 수정

### DIFF
--- a/apps/journeys/templates/journeys/route.html
+++ b/apps/journeys/templates/journeys/route.html
@@ -11,9 +11,15 @@
   <div class="app-container">
     <!-- Header -->
     <header class="page-header">
-      <button class="back-btn" onclick="goBack()">
+      {% if mode == "form" %}
+      <a href="{% url "journeys:leave" %}" class="back-btn" aria-label="메인으로 돌아가기">
         <i class="fas fa-arrow-left"></i>
-      </button>
+      </a>
+      {% elif mode == "guide" %}
+      <a href="{% url "journeys:route" %}?new=1" class="back-btn" aria-label="경로 입력 페이지로 돌아가기">
+        <i class="fas fa-arrow-left"></i>
+      </a>
+      {% endif %}
       <div class="page-title">길찾기</div>
       <a href="{% url 'journeys:leave' %}" class="home-btn" aria-label="메인으로 돌아가기">
         <i class="fas fa-home"></i>

--- a/static/css/route.css
+++ b/static/css/route.css
@@ -46,6 +46,7 @@ body {
     font-size: 18px;
     border-radius: 8px;
     transition: background 0.2s ease;
+    text-decoration: none;
 }
 
 .back-btn:hover {
@@ -556,33 +557,33 @@ body {
     .main-content {
         padding: 16px;
     }
-    
+
     .story-card {
         padding: 20px;
     }
-    
+
     .card-actions {
         flex-direction: column;
     }
-    
+
     .card-bottom {
         flex-direction: column;
     }
-    
+
     .action-btn {
         flex: none;
     }
-    
+
     .station-line {
         flex-direction: column;
         gap: 12px;
     }
-    
+
     .line-segment {
         flex-direction: row;
         margin: 0;
     }
-    
+
     .line {
         width: 40px;
         height: 2px;

--- a/static/js/route.js
+++ b/static/js/route.js
@@ -239,6 +239,7 @@ function selectStation(stationName, inputId) {
 //     }
 // }
 
+// 경로 안내 시 위치 안내 헤더(route-progress)
 function updateRouteStep() {
     if (!currentRoute) return;
 
@@ -422,18 +423,19 @@ function selectFacilityStation(stationName) {
 }
 
 // '이용 불가' 버튼 -> 대체 경로 안내
-// function reportClosure() {
-//     if (confirm('현재 경로에서 문제가 발생했나요? 대체 경로를 안내해드리겠습니다.')) {
-//         alert('죄송합니다. 빠른 대체 경로를 안내합니다');
+// TODO: '아직 구현되지 않은 기능입니다' 모달 변경
+function reportClosure() {
+    if (confirm('현재 경로에서 문제가 발생했나요? 대체 경로를 안내해드리겠습니다.')) {
+        alert('죄송합니다. 빠른 대체 경로를 안내합니다');
 
-//         // Mock alternative route
-//         setTimeout(() => {
-//             currentStep = 1;
-//             currentRoute.steps = generateAlternativeRoute();
-//             updateRouteStep();
-//         }, 2000);
-//     }
-// }
+        // Mock alternative route
+        setTimeout(() => {
+            currentStep = 1;
+            currentRoute.steps = generateAlternativeRoute();
+            updateRouteStep();
+        }, 2000);
+    }
+}
 
 // function generateAlternativeRoute() {
 //     // TODO: 실제 길찾기 API를 호출하고 그 결과를 파싱하여 경로 단계를 생성하는 로직으로 대체해야 합니다.
@@ -460,27 +462,27 @@ function selectFacilityStation(stationName) {
 // }
 
 // Navigation
-const appContainer = document.getElementById('wisheasy-app');
+// const appContainer = document.getElementById('wisheasy-app');
 
-function goBack() {
-    const routeGuidance = document.getElementById('routeGuidance');
-    // 경로 안내 카드가 화면에 표시된 상태라면, 경로 안내 카드를 숨기고 다시 검색 화면으로 이동
-    if (routeGuidance.style.display === 'block') {
-        routeGuidance.style.display = 'none';
-        document.querySelector('.input-section').style.display = 'block';
-        document.getElementById('startStation').value = ''
-        document.getElementById('endStation').value = ''
-    }
-    // 방문 기록이 있으면서, 동시에 외부 페이지를 통해 정상적으로 들어온 경우에만 뒤로가기
-    else if (window.history.length > 1 && document.referrer) {
-        window.history.back();
-    }
-    // 그렇지 않다면, 메인 페이지로 이동
-    else {
-        const mainPageUrl = appContainer.dataset.mainPageUrl;
-        window.location.href = mainPageUrl;
-    }
-}
+// function goBack() {
+//     const routeGuidance = document.getElementById('routeGuidance');
+//     // 경로 안내 카드가 화면에 표시된 상태라면, 경로 안내 카드를 숨기고 다시 검색 화면으로 이동
+//     if (routeGuidance.style.display === 'block') {
+//         routeGuidance.style.display = 'none';
+//         document.querySelector('.input-section').style.display = 'block';
+//         document.getElementById('startStation').value = ''
+//         document.getElementById('endStation').value = ''
+//     }
+//     // 방문 기록이 있으면서, 동시에 외부 페이지를 통해 정상적으로 들어온 경우에만 뒤로가기
+//     else if (window.history.length > 1 && document.referrer) {
+//         window.history.back();
+//     }
+//     // 그렇지 않다면, 메인 페이지로 이동
+//     else {
+//         const mainPageUrl = appContainer.dataset.mainPageUrl;
+//         window.location.href = mainPageUrl;
+//     }
+// }
 
 // Close modals when clicking outside
 document.addEventListener('click', function(e) {


### PR DESCRIPTION
route.js의 goBack() 함수에 의존하던 헤더 뒤로가기 버튼의 오류를 해결했습니다.

<button onclick> 대신 <a> 태그를 사용하고, Django 템플릿의 {% if mode %} 분기문을 활용하여 서버사이드에서 직접 링크를 제어하도록 변경했습니다. 동시에 route.js에서 goBack() 함수는 주석 처리를 통해 비활성화했습니다. 이를 통해 JS 의존성을 제거하고 안정성을 확보했습니다.

- mode=form일 때: 홈 (journeys:leave)으로 이동

- mode=guide일 때: 경로 입력창 (journeys:route?new=1)으로 이동