### PR TITLE
feat(accounts, common): 마이페이지 UI 구현 및 홈 버튼 로그인 연동

### DIFF
--- a/apps/accounts/templates/accounts/mypage.html
+++ b/apps/accounts/templates/accounts/mypage.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}설정 - 쉽길{% endblock title %}
+
+{% block css %}
+    <link rel="stylesheet" href="{% static "css/settings.css" %}">
+{% endblock css %}
+
+
+{% block content %}
+    <div class="app-container">
+        <!-- Header -->
+        <header class="page-header">
+            <button class="back-btn" onclick="goBack()">
+                <i class="fas fa-arrow-left"></i>
+            </button>
+            <div class="page-title">마이페이지</div>
+            <a href="{% url "common:index" %}" class="home-btn" aria-label="메인으로 돌아가기">
+                <i class="fas fa-home"></i>
+            </a>
+        </header>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            {# 프로필 프리뷰: 로그인 상태에서만 노출, 테스트용 코드 #}
+            {% if user.is_authenticated %}
+                {% comment %} signals로 Profile이 항상 만들어진다는 전제 {% endcomment %}
+                <div class="profile-card">
+                    <img src="{{ user.profile.profile_image }}" alt="profile" class="profile-image">
+                    <br>
+                    <div>
+                        <div><strong>{{ user.profile.name }}</strong> ({{ user.profile.nickname }})</div>
+                        <div style="color:#666;">{{ user.profile.google_mail }}</div>
+                    </div>
+                </div>
+            {% endif %}
+        </main>
+    </div>
+{% endblock content %}
+
+
+{% block js %}
+    <script src="{% static "js/settings.js" %}"></script>
+{% endblock js %}

--- a/apps/accounts/templates/accounts/settings.html
+++ b/apps/accounts/templates/accounts/settings.html
@@ -15,7 +15,7 @@
             <button class="back-btn" onclick="goBack()">
                 <i class="fas fa-arrow-left"></i>
             </button>
-            <div class="page-title">설정</div>
+            <div class="page-title">경로 우선순위 설정</div>
             <a href="{% url "common:index" %}" class="home-btn" aria-label="메인으로 돌아가기">
                 <i class="fas fa-home"></i>
             </a>
@@ -23,17 +23,6 @@
 
         <!-- Main Content -->
         <main class="main-content">
-            {# 프로필 프리뷰: 로그인 상태에서만 노출, 테스트용 코드#}
-            {% if user.is_authenticated %}
-                {% comment %} signals로 Profile이 항상 만들어진다는 전제 {% endcomment %}
-                <div class="profile-card" style="display:flex;gap:12px;align-items:center;margin-bottom:16px;padding:12px;border:1px solid #eee;border-radius:12px;">
-                <img src="{{ user.profile.profile_image }}" alt="profile" width="40" height="40" style="border-radius:50%;object-fit:cover;">
-                <div>
-                    <div><strong>{{ user.profile.name }}</strong> ({{ user.profile.nickname }})</div>
-                    <div style="color:#666;">{{ user.profile.google_mail }}</div>
-                </div>
-                </div>
-            {% endif %}
             <div class="info-box">
                 <p>드래그하여 선호하는 경로의 우선순위를 변경하세요.</p>
             </div>

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 app_name = "accounts"
 urlpatterns = [
+    path("mypage/", views.mypage, name="mypage"),
     path("settings/", views.settings, name="settings"),
 ]

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -2,6 +2,10 @@ from django.shortcuts import render
 
 
 # Create your views here.
+def mypage(request):
+    return render(request, "accounts/mypage.html")
+
+
 # 사용자의 경로 안내 우선 순위를 설정한다.
 def settings(request):
     return render(request, "accounts/settings.html")

--- a/apps/common/templates/common/index.html
+++ b/apps/common/templates/common/index.html
@@ -25,16 +25,16 @@
             <i class="fas fa-sign-out-alt"></i>
             로그아웃
           </a>
+          <a class="mypage-btn" href="{% url "accounts:mypage" %}">
+            <i class="fas fa-cog"></i>
+            마이페이지
+          </a>
         {% else %}
           <button class="login-btn" onclick="showLoginModal()">
             <i class="fas fa-user"></i>
             로그인
           </button>
         {% endif %}
-        <a class="mypage-btn" href="{% url "accounts:settings" %}">
-          <i class="fas fa-cog"></i>
-          마이페이지
-        </a>
       </div>
 
       <div class="main-buttons">

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -100,6 +100,27 @@ body {
     font-size: 14px;
 }
 
+/* Profile */
+.profile-card {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 16px;
+    padding: 12px;
+    border: 1px solid #eee;
+    border-radius: 12px;
+}
+
+.profile-image { 
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    padding-left: auto;
+    padding-right: auto;
+    object-fit: cover;
+}
+
+
 /* Priority List */
 .priority-list {
     display: flex;


### PR DESCRIPTION
마이페이지(settings.html)의 UI를 구현하고, 홈 화면에서 로그인 상태에 따라 마이페이지 버튼을 연동합니다.

- common(index.html): 로그인 상태에 따라 '마이페이지' 버튼 노출/숨김 처리
- accounts(settings.html): 불필요해진 '경로 안내 우선순위' 표시 항목 제거
- accounts(mypage.html): 헤더 UI 수정 ([←] [마이페이지] [홈])
- accounts(mypage.html): 프로필 정보(이미지, 이름, 닉네임, 이메일) 표시 기능 추가