### PR TITLE
fix(settings): .env 변수명 수정 및 local.py 중복 로드 제거

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -2,9 +2,6 @@
 
 from .base import *
 
-env_file = os.path.join(BASE_DIR, ".env")
-environ.Env.read_env(env_file)
-
 DEBUG = True
 ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 


### PR DESCRIPTION
- settings/base.py에 env 파일을 불러와 읽는 코드가 이미 있습니다.
- base.py를 상속받는 local.py에서 중복하여 불러올 필요가 없으므로 삭제합니다.