### PR TITLE
chore: 서버 변경으로 sudo 권한 재부여

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -211,7 +211,7 @@ jobs:
             sudo mkdir -p ./mysql/conf.d
             sudo rm -f ./mysql/conf.d/my.cnf
 
-            cat > ./mysql/conf.d/my.cnf << 'EOF'
+            sudo cat > ./mysql/conf.d/my.cnf << 'EOF'
             [mysqld]
             innodb_buffer_pool_size=64M
             max_connections=50


### PR DESCRIPTION
- 기존에 cat명령어에 sudo 권한이 없어서 mysql.conf 관련 에러가 떴음
- 이를 해결하고자 sudo 권한을 부여하여 서버 초기 세팅환경에서도 에러를 피하고자 함