### PR TITLE
fix(cicd): 권한 재설정으로 문제 해결

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -208,10 +208,10 @@ jobs:
             # -----------deploy:mysql-conf---------
             # MySQL 설정파일 초기화 및 재생성
             # (기존 파일이 있더라도 강제로 삭제 후 새로 작성)
-            sudo mkdir -p ./mysql/conf.d
-            sudo rm -f ./mysql/conf.d/my.cnf
+            mkdir -p ./mysql/conf.d
+            rm -f ./mysql/conf.d/my.cnf
 
-            sudo cat > ./mysql/conf.d/my.cnf << 'EOF'
+            cat > ./mysql/conf.d/my.cnf << 'EOF'
             [mysqld]
             innodb_buffer_pool_size=64M
             max_connections=50


### PR DESCRIPTION
- 기존에 sudo 명령을 일부만 부여하였더니 crud 권한이 없어 workflows가 fail함.
- 권한을 사용자 권한으로 통일하고자 하여 sudo 명령어를 모두 삭제함