### PR TITLE
feat(search): 자동완성 API 결과에서 호선 정보 그룹화

### DIFF
--- a/apps/stations/views.py
+++ b/apps/stations/views.py
@@ -15,15 +15,34 @@ def search_stations(request):
     query = request.GET.get('q', None)
     results = []
 
-    if query and len(query) > 0: # 검색어가 있고 0글자 이상일 때
-        # 'name__icontains' : 대소문자 구분 없이 포함
-        # 'name__startswith' : 해당 글자로 시작 (이걸 더 추천)
-        stations = Station.objects.filter(name__startswith=query)[:10] # 최대 10개
+    if query and len(query) > 0:
+        
+        # 1. 'Station' 모델에서 'name'으로 검색합니다.
+        stations = Station.objects.filter(
+            name__startswith=query
+        )
+        
+        # 2. 'prefetch_related'로 N+1 쿼리 문제를 방지합니다.
+        #    (각 Station에 연결된 Line 정보 10개를 미리 한 번에 가져옴)
+        stations = stations.prefetch_related('lines')[:10]
 
-        for station in stations:
+        # 3. 각 Station 객체를 순회합니다.
+        for s in stations:
+            # 4. 해당 역(s)에 연결된 모든 호선(l)의 이름을 리스트로 만듭니다.
+            #    (예: ["2호선", "신분당선"])
+            line_names = [l.name for l in s.lines.all()]
+            
+            # 5. 리스트를 ", "로 연결된 하나의 문자열로 만듭니다.
+            #    (예: "2호선, 신분당선")
+            lines_str = ", ".join(line_names)
+            
             results.append({
-                'name': station.name,
-                'line': station.line,
+                'name': s.name,    # 역 이름 (예: "강남")
+                'line': lines_str  # 호선 이름 (예: "2호선, 신분당선")
             })
+        
+        # 최종 결과 리스트에서 10개만 반환
+        return JsonResponse({'results': results[:10]})
 
-    return JsonResponse({'results': results})
+    # 검색어가 없는 경우 빈 리스트 반환
+    return JsonResponse({'results': []})


### PR DESCRIPTION
- `search_stations` 함수의 로직을 개선합니다.
- 기존: "강남" 검색 시 "강남역 (2호선)", "강남역 (신분당선)" 등 역에 연결된 호선마다 별도의 결과로 반환했습니다.
- 변경: "강남역 (2호선, 신분당선)"처럼, 하나의 역에 연결된 모든 호선(line) 이름을 `, `로 묶어(join) 하나의 결과로 반환하도록 수정했습니다.