### PR TITLE
feat(route): 경로 안내 페이지 UI 개편 및 네비게이션 로직 변경

### DIFF
--- a/apps/journeys/templates/journeys/route.html
+++ b/apps/journeys/templates/journeys/route.html
@@ -117,17 +117,22 @@
           <div class="instruction-section">
             <form method="post" style="display: contents;">
               {% csrf_token %}
+              
               <button class="nav-btn prev-btn" id="prevBtn" name="action" value="prev" {% if not has_prev %}disabled{% endif %}>
-                <span>이전</span>
+                <i class="fas fa-chevron-left"></i>
               </button>
 
               <div class="instruction-content">
+                <div class="step-indicator">
+                    Step {{ idx|add:1 }} / {{ count }}
+                </div>
+
                 <div class="instruction-icon" id="instructionIcon">
                   <i class="fas fa-walking"></i>
                 </div>
+                
                 <div class="instruction-text" id="instructionText">
-                  <div class="instruction-line"><strong>스텝 {{ idx|add:1 }} / {{ count }}</strong></div>
-                  <div class="instruction-line">{{ step_text }}</div>
+                  {{ step_text }}
                 </div>
               </div>
 
@@ -136,7 +141,7 @@
                       name="action"
                       value="next"
                       data-has-next="{{ has_next|yesno:'1,0' }}">
-                <span>다음</span>
+                <i class="fas fa-chevron-right"></i>
               </button>
             </form>
           </div>
@@ -241,7 +246,7 @@
     var idx = parseInt(icon.dataset.idx || '0', 10);
     var count = parseInt(icon.dataset.count || '1', 10);
     var ratio = (count > 1) ? (idx / (count - 1)) : 0;
-    icon.style.left = 'calc(' + (ratio * 100) + '% - 12px)';
+    icon.style.left = 'calc(25px + (100% - 50px) * ' + ratio + ')';
   })();
 </script>
 

--- a/static/css/route.css
+++ b/static/css/route.css
@@ -284,82 +284,86 @@ body {
 
 /* Main Instruction */
 .instruction-section {
-    /* flex: 1; */ /* Removed */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 60px 20px; /* Reduced padding */
     position: relative;
-}
-
-.nav-btn {
-    position: absolute;
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
-    border: none;
-    background: #0052A4; /* Changed */
-    color: white;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 4px 16px rgba(0, 123, 255, 0.3);
-}
-
-.nav-btn:hover {
-    background: #003B7A; /* Darker shade */
-    transform: scale(1.05);
-}
-
-.prev-btn {
-    background: #BDBDBD; /* Changed */
-}
-
-.prev-btn:hover {
-    background: #9E9E9E; /* Darker grey */
-}
-
-.prev-btn {
-    left: 20px;
-}
-
-.next-btn {
-    right: 20px;
-}
-
-.instruction-content {
+    min-height: 150px;
+    padding: 20px 0;
     text-align: center;
-    max-width: 300px;
-}
-
-.instruction-icon {
-    font-size: 48px;
-    color: #0052A4; /* Changed */
+    background-color: #fff;
+    border-radius: 12px; 
+    /* box-shadow: 0 2px 8px rgba(0,0,0,0.05); */
     margin-bottom: 20px;
 }
 
-.instruction-text {
-    color: #424242; /* Changed */
-    font-size: 22px; /* Slightly smaller font */
+/* 스텝 표시 (아이콘 상단, 작은 글씨) */
+.step-indicator {
+    font-size: 12px;
+    color: #888;
     font-weight: 600;
-    line-height: 1.4;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 12px;
 }
 
-.instruction-text .highlight {
-    color: #0052A4; /* Changed */
-    font-weight: 700;
+.nav-btn {
+    position: absolute; 
+    top: 50%;
+    transform: translateY(-50%);
+    
+    background: transparent;
+    border: none;
+    color: #ccc; 
+    font-size: 24px; 
+    padding: 15px; 
+    cursor: pointer;
+    z-index: 10;
+    transition: color 0.2s ease;
 }
 
-.instruction-line {
-    margin-bottom: 8px;
+.nav-btn:hover:not(:disabled) {
+    color: #333; /* 호버 시 진하게 */
 }
 
-.instruction-line:last-child {
-    margin-bottom: 0;
+.nav-btn:disabled {
+    color: #f0f0f0; /* 비활성화 시 아주 연하게 */
+    cursor: default;
+}
+
+/* 버튼 위치 지정 */
+.nav-btn.prev-btn {
+    left: 0;
+}
+
+.nav-btn.next-btn {
+    right: 0;
+}
+
+/* 안내 콘텐츠 영역 */
+.instruction-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0 60px; /* 양옆 버튼과 겹치지 않도록 충분한 여백 (중요!) */
+}
+
+/* 아이콘 스타일 */
+.instruction-icon {
+    font-size: 40px;
+    color: #333;
+    margin-bottom: 16px;
+}
+
+/* 안내 텍스트 (작은 글씨, 가독성) */
+.instruction-text {
+    font-size: 16px; /* 너무 작지 않게 설정 */
+    line-height: 1.5;
+    color: #444;
+    word-break: keep-all; /* 한글 단어 중간 끊김 방지 */
+    font-weight: 500;
 }
 
 /* Bottom Action Buttons */

--- a/static/js/route.js
+++ b/static/js/route.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function initializeRoutePage() {
     setupStationInputs();
+    updateTrainPosition();
     console.log('길찾기 페이지가 로드되었습니다.');
 }
 
@@ -92,6 +93,29 @@ function selectStation(stationName, inputId) {
 
     input.value = stationName;
     suggestions.style.display = 'none';
+}
+
+/* 현재 스텝(idx)에 맞춰 진행 바의 기차 아이콘 위치를 설정하는 함수 */
+function updateTrainPosition() {
+    const trainIcon = document.getElementById('trainIcon');
+    if (!trainIcon) return;
+
+    // HTML data 속성에서 값 가져오기 (Django 템플릿에서 렌더링된 값)
+    const idx = parseInt(trainIcon.dataset.idx) || 0;     // 현재 인덱스 (0부터 시작)
+    const count = parseInt(trainIcon.dataset.count) || 1; // 전체 단계 수
+
+    // 진행률 계산 (0% ~ 100%)
+    // idx가 0이면 0%, idx가 count-1이면 100%가 되도록 계산
+    let percentage = 0;
+    if (count > 1) {
+        percentage = (idx / (count - 1)) * 100;
+    }
+
+    // 범위 제한 (0~100)
+    percentage = Math.min(100, Math.max(0, percentage));
+
+    // CSS left 속성 업데이트
+    trainIcon.style.left = `${percentage}%`;
 }
 
 // '길찾기 시작' 버튼 -> 경로 찾기
@@ -243,78 +267,78 @@ function selectStation(stationName, inputId) {
 // }
 
 // 경로 안내 시 위치 안내 헤더(route-progress)
-function updateRouteStep() {
-    if (!currentRoute) return;
+// function updateRouteStep() {
+//     if (!currentRoute) return;
 
-    const step = currentRoute.steps[currentStep - 1];
+//     const step = currentRoute.steps[currentStep - 1];
 
-    // Update instruction icon
-    const instructionIcon = document.getElementById('instructionIcon').querySelector('i');
-    instructionIcon.className = `fas ${getIcon(step.icon)}`;
+//     // Update instruction icon
+//     const instructionIcon = document.getElementById('instructionIcon').querySelector('i');
+//     instructionIcon.className = `fas ${getIcon(step.icon)}`;
 
-    // Update instruction text
-    const instructionText = document.getElementById('instructionText');
-    instructionText.innerHTML = step.instruction.map(line =>
-        `<div class="instruction-line">${line}</div>`
-    ).join('');
+//     // Update instruction text
+//     const instructionText = document.getElementById('instructionText');
+//     instructionText.innerHTML = step.instruction.map(line =>
+//         `<div class="instruction-line">${line}</div>`
+//     ).join('');
 
-    // Update time labels (2 segments only)
-    document.getElementById('startTime').textContent = step.times[0];
-    document.getElementById('endTime').textContent = step.times[1];
+//     // Update time labels (2 segments only)
+//     document.getElementById('startTime').textContent = step.times[0];
+//     document.getElementById('endTime').textContent = step.times[1];
 
-    // Update progress bar color based on line
-    const progressBar = document.querySelector('.progress-line');
-    const lineClass = getLineClass(step.line);
+//     // Update progress bar color based on line
+//     const progressBar = document.querySelector('.progress-line');
+//     const lineClass = getLineClass(step.line);
 
-    // Remove old line classes from progress bar only
-    progressBar.className = 'progress-line';
-    if (lineClass) {
-        progressBar.classList.add(lineClass);
-    }
+//     // Remove old line classes from progress bar only
+//     progressBar.className = 'progress-line';
+//     if (lineClass) {
+//         progressBar.classList.add(lineClass);
+//     }
 
-    // Show/hide transfer marker
-    const transferMarker = document.getElementById('transferMarker');
+//     // Show/hide transfer marker
+//     const transferMarker = document.getElementById('transferMarker');
 
-    if (step.position === 'transfer') {
-        transferMarker.style.display = 'flex';
-    } else {
-        transferMarker.style.display = 'none';
-    }
+//     if (step.position === 'transfer') {
+//         transferMarker.style.display = 'flex';
+//     } else {
+//         transferMarker.style.display = 'none';
+//     }
 
-    // Update train position based on step position (centered on markers)
-    const trainIcon = document.getElementById('trainIcon');
-    let trainPosition;
+//     // Update train position based on step position (centered on markers)
+//     const trainIcon = document.getElementById('trainIcon');
+//     let trainPosition;
 
-    switch(step.position) {
-        case 'start':
-            trainPosition = '10%';
-            break;
-        case 'transfer':
-            trainPosition = '50%';
-            break;
-        case 'end':
-            trainPosition = '90%';
-            break;
-        default:
-            trainPosition = '10%';
-    }
+//     switch(step.position) {
+//         case 'start':
+//             trainPosition = '10%';
+//             break;
+//         case 'transfer':
+//             trainPosition = '50%';
+//             break;
+//         case 'end':
+//             trainPosition = '90%';
+//             break;
+//         default:
+//             trainPosition = '10%';
+//     }
 
-    trainIcon.style.left = trainPosition;
+//     trainIcon.style.left = trainPosition;
 
-    // Update buttons
-    const prevBtn = document.getElementById('prevBtn');
-    const nextBtn = document.getElementById('nextBtn');
+//     // Update buttons
+//     const prevBtn = document.getElementById('prevBtn');
+//     const nextBtn = document.getElementById('nextBtn');
 
-    prevBtn.style.display = currentStep > 1 ? 'flex' : 'none';
+//     prevBtn.style.display = currentStep > 1 ? 'flex' : 'none';
 
-    if (currentStep === totalSteps) {
-        nextBtn.innerHTML = '<span>완료</span>';
-        nextBtn.onclick = endGuidance;
-    } else {
-        nextBtn.innerHTML = '<span>다음</span>';
-        nextBtn.onclick = nextStep;
-    }
-}
+//     if (currentStep === totalSteps) {
+//         nextBtn.innerHTML = '<span>완료</span>';
+//         nextBtn.onclick = endGuidance;
+//     } else {
+//         nextBtn.innerHTML = '<span>다음</span>';
+//         nextBtn.onclick = nextStep;
+//     }
+// }
 
 function updateRouteVisual(stations) {
     const stationLine = document.getElementById('stationLine');


### PR DESCRIPTION
- 경로 안내 카드의 디자인을 사용자 친화적으로 개선했습니다.
  - 스텝 정보(Step X/Y)를 아이콘 상단으로 이동하고 가독성을 높였습니다.
  - 이전/다음 버튼을 텍스트 대신 화살표 아이콘(<, >)으로 변경하고, 카드 양옆으로 배치하여 접근성을 개선했습니다.
  - 안내 텍스트의 크기와 여백을 조정하여 버튼과 겹치지 않도록 수정했습니다.

- 스텝 이동 로직을 JavaScript 클라이언트 처리에서 서버 사이드 렌더링(Form POST) 방식으로 변경했습니다.
  - route.js에서 불필요해진 클라이언트 상태 관리 코드를 제거하고, 페이지 초기화 및 기차 아이콘 위치 업데이트 로직 위주로 리팩토링했습니다.

- 진행률 표시줄(Progress Bar)의 기차 아이콘 위치 계산식을 수정했습니다.
  - 아이콘이 역 마커의 중심점에 정확히 위치하도록 CSS calc 수식을 보정했습니다. (시작점 25px ~ 끝점 100%-25px)