### PR TITLE
chore(api): REST API 구축을 위한 rest_framework 기본 설정 추가

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -55,6 +55,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")  # 프록시가 �
 # Application definition
 
 INSTALLED_APPS = [
+    "rest_framework"
     "apps.accounts.apps.AccountsConfig",
     "apps.stations",
     "apps.journeys",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ PyJWT==2.8.0
 cryptography==46.0.2
 pandas
 networkx>=3.3
+djangorestframework==3.16.1


### PR DESCRIPTION
- requirements.txt에 djangorestframework 추가
- settings/base.py의 INSTALLED_APPS에 rest_framework 등록
- 향후 API 엔드포인트 구현을 위한 초기 환경 구성