### PR TITLE
fix(settings): INSTALLED_APPS 쉼표 누락으로 인한 배포 오류 수정

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -55,7 +55,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")  # 프록시가 �
 # Application definition
 
 INSTALLED_APPS = [
-    "rest_framework"
+    "rest_framework",
     "apps.accounts.apps.AccountsConfig",
     "apps.stations",
     "apps.journeys",


### PR DESCRIPTION
- settings 파일에서 앱 등록 시 누락된 쉼표 추가
- 구문 오류로 인해 배포 과정에서 실패하던 문제 해결