### PR TITLE
feat(api): 역 편의시설 조회 API 및 전용 URL 구조 추가

### DIFF
--- a/apps/journeys/serializers.py
+++ b/apps/journeys/serializers.py
@@ -1,0 +1,27 @@
+from rest_framework import serializers
+from .models import Facility, FacilityLoc
+
+class FacilitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Facility
+        fields = ['facility_id', 'facility_name']
+
+class FacilityLocSerializer(serializers.ModelSerializer):
+    # FK로 따라가서 이름까지 같이 내려주기
+    station_name = serializers.CharField(source='station.name', read_only=True)
+    line_name = serializers.CharField(source='line.name', read_only=True)
+    facility_name = serializers.CharField(source='facility.facility_name', read_only=True)
+
+
+    class Meta:
+        model = FacilityLoc
+        fields = [
+            'id',
+            'detail_loc',
+            'station',
+            'station_name',
+            'line',
+            'line_name',
+            'facility',
+            'facility_name'
+        ]

--- a/apps/stations/api_urls.py
+++ b/apps/stations/api_urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+from . import views 
+from apps.journeys.views import StationFacilityListView  # journeys 쪽 뷰 재사용
+
+app_name = "stations_api"
+
+urlpatterns = [
+    # 역 검색 API
+    path("search/", views.search_stations, name="search_stations"),
+    # 역 편의시설 API
+    path(
+        "<int:station_id>/facilities/",
+        StationFacilityListView.as_view(),
+        name="station-facilities",
+    ),
+]

--- a/config/urls.py
+++ b/config/urls.py
@@ -25,5 +25,5 @@ urlpatterns = [
     path("stations/", include(("apps.stations.urls", "stations"), namespace="stations")),
     path("journeys/", include(("apps.journeys.urls", "journeys"), namespace="journeys")),
     # /api/stations/로 시작하는 모든 URL은 stations.urls로 위임
-    path("api/stations/", include("apps.stations.urls")),
+    path("api/stations/", include(("apps.stations.api_urls", "stations_api"), namespace="stations_api")),
 ]


### PR DESCRIPTION
- FacilitySerializer, FacilityLocSerializer 추가로 Facility/FacilityLoc JSON 응답 지원
- StationFacilityListView(ListAPIView) 구현: 역(station_id) 및 선택적 line_id 기반 편의시설 목록 반환
- select_related(station, line, facility)로 N+1 최소화 및 FK 이름 필드(station_name 등) 직렬화
- apps/stations/urls.py는 웹용만 유지하도록 정리
- apps/stations/api_urls.py 신설: 검색/편의시설 API 라우트 분리
- config/urls.py에 /api/stations/ 네임스페이스 추가 (stations_api)