### PR TITLE
feat(stations): 호선별 고유 색상 적용을 위한 CSS 및 JS 로직 구현

### DIFF
--- a/static/css/station_info.css
+++ b/static/css/station_info.css
@@ -201,53 +201,37 @@ body {
     flex-wrap: wrap;
 }
 
+/* =========================================
+   호선별 뱃지 컬러 스타일
+   ========================================= */
+
+/* 기본 뱃지 스타일 보강 */
 .line-badge {
     padding: 6px 12px;
     border-radius: 20px;
-    font-size: 12px;
+    font-size: 14px;
+    color: #fff;             /* 글자색 흰색 */
+    background-color: #ccc;  /* 매칭 안될 경우 기본 회색 */
+    border: none;            /* 테두리 제거 */
     font-weight: 600;
-    color: white;
 }
 
-.line-2 {
-    background: #00a651;
-}
+/* 1~9호선 */
+.line-1 { background-color: #0052A4; }
+.line-2 { background-color: #00A84D; }
+.line-3 { background-color: #EF7C1C; }
+.line-4 { background-color: #00A4E4; }
+.line-5 { background-color: #996CAC; }
+.line-6 { background-color: #CD7C2F; }
+.line-7 { background-color: #747F00; }
+.line-8 { background-color: #E6186C; }
+.line-9 { background-color: #BB8336; }
 
-.line-bundang {
-    background: #f5a200;
-}
-
-.line-1 {
-    background: #003499;
-}
-
-.line-3 {
-    background: #ff6600;
-}
-
-.line-4 {
-    background: #00a2d1;
-}
-
-.line-5 {
-    background: #996cac;
-}
-
-.line-6 {
-    background: #cd7c2f;
-}
-
-.line-7 {
-    background: #747f00;
-}
-
-.line-8 {
-    background: #e6186c;
-}
-
-.line-9 {
-    background: #b7c452;
-}
+/* 기타 노선 (분당선, 신분당선, 경의중앙선 등) */
+.line-bundang { background-color: #F5A200; }      /* 수인분당선 (노란색) */
+.line-shinbundang { background-color: #D4003B; }  /* 신분당선 (빨간색) */
+.line-gyeongui { background-color: #77C4A3; }    /* 경의중앙선 (옥색) */
+.line-airport { background-color: #0090D2; }      /* 공항철도 (하늘색) */
 
 /* Info Tabs */
 .info-tabs {

--- a/static/js/station_info.js
+++ b/static/js/station_info.js
@@ -34,6 +34,32 @@ const FACILITY_CONFIG = {
     }
 };
 
+/**
+ * 호선 명칭을 CSS 클래스 접미사로 변환
+ * 예: "2호선" -> "2", "신분당선" -> "shinbundang"
+ */
+function getLineClass(lineName) {
+    if (!lineName) return 'default';
+
+    // 1. "N호선" 패턴에서 숫자만 추출 ("7호선" -> "7")
+    const match = lineName.match(/(\d+)호선/);
+    if (match) {
+        return match[1]; // CSS 클래스 .line-7 매핑
+    }
+
+    // 2. 숫자가 없는 노선 매핑 (필요한 노선 추가)
+    const lineMap = {
+        '수인분당': 'bundang',
+        '신분당선': 'shinbundang',
+        '경의중앙': 'gyeongui',
+        '공항철도': 'airport',
+        '경춘': 'gyeongchun',
+        '우이신설': 'ui'
+    };
+
+    return lineMap[lineName] || 'default';
+}
+
 // Initialize the app
 document.addEventListener('DOMContentLoaded', function() {
     initializeStationPage();


### PR DESCRIPTION
API 데이터("7호선") 형식을 파싱하여 올바른 CSS 클래스(.line-7)를 매핑하고, 노선별 브랜드 색상을 적용했습니다.

- station_info.js: "getLineClass" 함수 추가 (정규식을 통해 "N호선" 파싱 및 기타 노선 매핑 처리)
- station_info.css: 1~9호선 및 주요 노선(분당, 신분당 등)에 대한 배경색 스타일 정의
- showStationInfo 함수: API의 "lines" 객체 배열 구조에 맞춰 뱃지 렌더링 로직 수정