### PR TITLE
feat(stations): 역 상세 페이지 내 호선별 편의시설 분리 표시 구현

### DIFF
--- a/static/css/station_info.css
+++ b/static/css/station_info.css
@@ -511,3 +511,27 @@ body {
     outline: 2px solid #007bff;
     outline-offset: 2px;
 }
+
+/* 호선별 편의시설 섹션 */
+.line-facilities-section {
+    margin-bottom: 24px;
+}
+
+.line-facilities-section:last-child {
+    margin-bottom: 0;
+}
+
+.line-subtitle {
+    font-size: 15px;
+    font-weight: 600;
+    color: #333;
+    margin: 0 0 12px 0;
+    padding-bottom: 8px;
+    border-bottom: 2px solid #e0e0e0;
+}
+
+.facility-list-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}

--- a/static/js/station_info.js
+++ b/static/js/station_info.js
@@ -144,15 +144,36 @@ async function triggerStationSearch() {
             return;
         }
 
-        // 2. 편의시설 API로 편의시설 정보 가져오기
-        const facilities = await fetchStationFacilities(station.id);
+        // 2. 호선별로 편의시설 API 호출
+        const lines = station.lines || [];
+
+        if (lines.length === 0) {
+            showStationInfo({
+                id: station.id,
+                name: station.name,
+                lines: [],
+                lineFacilities: []
+            });
+            return;
+        }
+
+        // 각 호선별로 편의시설 조회
+        const lineFacilitiesData = await Promise.all(
+            lines.map(async (line) => {
+                const facilities = await fetchStationFacilities(station.id, line.id);
+                return {
+                    lineName: line.name,
+                    facilities: facilities
+                };
+            })
+        );
 
         // 3. 데이터 결합하여 표시
         showStationInfo({
             id: station.id,
             name: station.name,
-            lines: station.lines,  // 검색 API에서 받은 호선 정보
-            facilities: facilities  // 편의시설 API에서 받은 시설 정보
+            lines: station.lines,
+            lineFacilities: lineFacilitiesData
         });
 
     } catch (error) {
@@ -192,48 +213,68 @@ function showStationInfo(station) {
     // Hide search section and no results
     document.querySelector('.search-section').style.display = 'none';
     document.getElementById('noResults').style.display = 'none';
-    
+
     // Update station header
     document.getElementById('stationName').textContent = station.name;
-    
+
     // Update line badges
     const lineContainer = document.getElementById('stationLines');
     lineContainer.innerHTML = station.lines.map(line =>
         `<span class="line-badge line-${getLineClass(line.name)}">${line.name}</span>`
     ).join('');
 
-    // Update facilities
-    updateFacilities(station.facilities);
+    // Update facilities (호선별 데이터 전달)
+    updateFacilities(station.lineFacilities);
 
     // Show station info
     document.getElementById('stationInfo').style.display = 'block';
-    
+
     // Scroll to station info
-    document.getElementById('stationInfo').scrollIntoView({ 
-        behavior: 'smooth' 
+    document.getElementById('stationInfo').scrollIntoView({
+        behavior: 'smooth'
     });
 }
 
-function updateFacilities(facilities) {
+function updateFacilities(lineFacilitiesData) {
     const container = document.getElementById('facilityList');
 
-    // 역 정보 페이지용 필터링 적용
-    const filteredFacilities = filterFacilitiesForStationInfo(facilities);
-
-    if (filteredFacilities.length === 0) {
+    if (!lineFacilitiesData || lineFacilitiesData.length === 0) {
         container.innerHTML = '<p class="no-data">편의시설 정보가 없습니다.</p>';
         return;
     }
 
-    container.innerHTML = filteredFacilities.map(facility => `
-        <div class="facility-item">
-            <i class="${facility.icon}"></i>
-            <div class="facility-detail">
-                <span class="facility-name">${facility.displayName}</span>
-                <span class="facility-location">${facility.detail_loc || '위치 정보 없음'}</span>
+    // 각 호선별로 편의시설 필터링 및 표시 여부 확인
+    const lineFacilitiesHTML = lineFacilitiesData.map(data => {
+        const filteredFacilities = filterFacilitiesForStationInfo(data.facilities);
+
+        if (filteredFacilities.length === 0) {
+            return ''; // 편의시설이 없는 호선은 표시하지 않음
+        }
+
+        return `
+            <div class="line-facilities-section">
+                <h5 class="line-subtitle">${data.lineName}</h5>
+                <div class="facility-list-inner">
+                    ${filteredFacilities.map(facility => `
+                        <div class="facility-item">
+                            <i class="${facility.icon}"></i>
+                            <div class="facility-detail">
+                                <span class="facility-name">${facility.displayName}</span>
+                                <span class="facility-location">${facility.detail_loc || '위치 정보 없음'}</span>
+                            </div>
+                        </div>
+                    `).join('')}
+                </div>
             </div>
-        </div>
-    `).join('');
+        `;
+    }).filter(html => html).join('');
+
+    if (!lineFacilitiesHTML) {
+        container.innerHTML = '<p class="no-data">편의시설 정보가 없습니다.</p>';
+        return;
+    }
+
+    container.innerHTML = lineFacilitiesHTML;
 }
 
 // ========================================


### PR DESCRIPTION
환승역(다중 호선) 조회 시 편의시설 정보가 섞여서 표시되던 문제를 해결하기 위해, 호선별로 섹션을 나누어 정보를 제공하도록 로직을 개선했습니다.

- JS 로직 변경 (station_info.js):
  - 'triggerStationSearch': 해당 역의 모든 호선에 대해 'fetchStationFacilities'를 병렬 호출('Promise.all')하여 호선별 데이터 구조화
  - 'updateFacilities': 단순 목록 나열 방식에서 호선명(Subtitle)을 포함한 섹션 단위 렌더링으로 변경
  - 'filterFacilitiesForStationInfo': 호선별로 필터링 로직이 적용되도록 수정

- UI 스타일 추가 (station_info.css):
  - '.line-facilities-section': 호선별 정보 구분을 위한 마진 및 레이아웃 스타일 정의
  - '.line-subtitle': 호선 이름(예: 2호선, 7호선)을 표시하는 소제목 스타일 추가