### PR TITLE
fix(search): 역 검색 자동완성 선택 후 리스트가 다시 열리는 오류 수정

### DIFF
--- a/static/js/route.js
+++ b/static/js/route.js
@@ -41,16 +41,30 @@ function setupStationInputs() {
 
 function setupAutocomplete(input, suggestionsId) {
     const suggestionsContainer = document.getElementById(suggestionsId);
+    let isStationSelected = false; // 역 선택 상태를 추적하는 플래그
 
     // Use event delegation for suggestion clicks
     suggestionsContainer.addEventListener('mousedown', function(e) {
         if (e.target && e.target.matches('div.suggestion-item')) {
             selectStation(e.target.dataset.stationName, input.id);
+
+            // 역 선택 시 리스트를 즉시 숨기고 선택 상태로 변경
+            suggestionsContainer.style.display = 'none';
+            suggestionsContainer.innerHTML = ''; 
+            isStationSelected = true;
         }
+    });
+    
+    // 사용자가 다시 타이핑을 시작하면 선택 상태 해제
+    input.addEventListener('input', function() {
+        isStationSelected = false;
     });
 
     // debounce와 fetchStations 사용
     input.addEventListener('input', debounce(async function() { // <--- 1. debounce 적용
+        // 역이 선택된 상태라면 자동완성 검색을 수행하지 않음 (지연된 호출 방지)
+        if (isStationSelected) return;
+
         const value = this.value;
         suggestionsContainer.innerHTML = ''; // 이전 제안 삭제
 
@@ -61,6 +75,12 @@ function setupAutocomplete(input, suggestionsId) {
 
         // 2. API 호출로 stations 데이터를 가져옴 (search-util.js의 함수 사용)
         const stations = await fetchStations(value);
+
+        // 비동기 요청 완료 후에도 사용자가 그 사이 역을 선택했다면 리스트를 열지 않음
+        if (isStationSelected) {
+            suggestionsContainer.style.display = 'none';
+            return;
+        }
 
         if (stations.length > 0) {
             stations.forEach(station => {

--- a/static/js/station_info.js
+++ b/static/js/station_info.js
@@ -73,16 +73,30 @@ function initializeStationPage() {
 function setupStationSearch() {
     const searchInput = document.getElementById('stationSearch');
     const suggestionsContainer = document.getElementById('searchSuggestions');
+    let isStationSelected = false; // 역 선택 여부 확인용 플래그
 
     // Use event delegation for suggestion clicks
     suggestionsContainer.addEventListener('mousedown', function(e) {
         if (e.target && e.target.matches('div.suggestion-item')) {
             selectStation(e.target.dataset.stationName);
+
+            // 역 선택 시 리스트를 즉시 닫고 플래그 설정
+            suggestionsContainer.style.display = 'none';
+            suggestionsContainer.innerHTML = '';
+            isStationSelected = true;
         }
     });
     
+    // 사용자가 다시 입력을 시작하면 플래그 해제
+    searchInput.addEventListener('input', function() {
+        isStationSelected = false;
+    });
+
     // debounce와 fetchStations 사용
     searchInput.addEventListener('input', debounce(async function() { // <--- 1. debounce 적용
+        // 역이 선택된 상태라면 검색 로직 중단
+        if (isStationSelected) return;
+
         const value = this.value;
         suggestionsContainer.innerHTML = ''; // 이전 제안 삭제
 
@@ -93,6 +107,12 @@ function setupStationSearch() {
 
         // 2. API 호출로 stations 데이터를 가져옴 (search-util.js의 함수 사용)
         const stations = await fetchStations(value);
+
+        // 비동기 응답 후에도 선택 상태라면 리스트 표시 안 함
+        if (isStationSelected) {
+            suggestionsContainer.style.display = 'none';
+            return;
+        }
 
         if (stations.length > 0) {
             stations.forEach(station => {


### PR DESCRIPTION
자동완성 목록에서 역을 선택하여 입력값이 채워진 직후, 디바운스(debounce)된 검색 로직이 뒤늦게 실행되어 리스트가 다시 노출되는 문제를 해결했습니다.

- route.js, station_info.js:
  - 'isStationSelected' 플래그를 도입하여 역 선택 상태 추적
  - 목록 클릭('mousedown') 시 플래그를 활성화하고 리스트를 즉시 숨김 처리
  - 검색 로직('debounce') 실행 전후에 플래그를 확인하여, 역 선택 직후에는 API 호출 및 리스트 렌더링을 차단
  - 사용자가 입력을 다시 시작하면 플래그를 해제하여 정상적인 검색이 가능하도록 수정