### PR TITLE
feat(cicd): csv 파일 업로드 전 if 로직 삭제

### DIFF
--- a/.github/workflows/cicd_web-db-nginx.yml
+++ b/.github/workflows/cicd_web-db-nginx.yml
@@ -500,16 +500,12 @@ jobs:
             "
 
             # (3) CSV 파일 DB에 업로드
-            # 최초  1회 / 내용 변경 시에만 실행 예정
+            # db 변경 시마다 항상 최신 파일을 적재하도록 로직 변경함. 되돌리고 싶으면 11월 30일 작업내역 참고.
             sudo docker compose -f "$COMPOSE_FILE" --env-file .env.prod run --rm --no-deps web sh -lc "
               set -Eeuo pipefail
               echo '[deploy:load_csv] (3/5) CSV 데이터 적재 시작...';
               mkdir -p /data && touch /data/.keep
 
-              if [ -f /data/.csv_loaded ]; then
-                echo '[deploy:load_csv] (3/5) 이미 적재 완료됨. 스킵합니다.';
-                exit 0
-              fi
               python manage.py load_csv --file station.csv --settings=config.settings.prod
               python manage.py load_csv --file line.csv --settings=config.settings.prod
               python manage.py load_csv --file stationline.csv --settings=config.settings.prod


### PR DESCRIPTION
- - 기존에는 이미 기적재된 csv 파일에 대해서는 다시 적재하지 않음.
- 그러나, 최근 csv 파일의 변경은 잦게 이루어지며
- 해당 부분 로직을 변경할 필요성이 생김
- 이에 if 문을 삭제하여, 항상 최신 csv 를 기준으로 db 업데이트 하는 전략으로 변경함