### PR TITLE
fix(journeys): 경로 생성 내부 오류를 사용자에게 노출하지 않도록 변경

### DIFF
--- a/apps/journeys/services/guide.py
+++ b/apps/journeys/services/guide.py
@@ -6,6 +6,13 @@ import networkx as nx
 from apps.journeys.models import Station, Line, Node, Edge, FastGate, Lines
 from apps.journeys.management.commands.build_graph import get_graph
 
+class RouteBuildError(Exception):
+    """그래프에서 최단 경로를 만들지 못했을 때"""
+    pass
+
+class GuidanceBuildError(Exception):
+    """노드 간 안내 문장을 만들지 못했을 때"""
+    pass
 
 # Lines → dict 로드
 def load_lines_from_db() -> dict[str, list[str]]:
@@ -191,6 +198,7 @@ def get_subway_route(
         ("아현", "2호선 이대 방면 승강장", "1번출구", ("2호선", "도착역")),
       ]
     """
+    
     # 1) DB에서 노선별 역 순서 로드 + 그래프 로드
     line_data = load_lines_from_db()
     G = get_graph()
@@ -201,10 +209,11 @@ def get_subway_route(
 
     if not start_nodes or not end_nodes:
         # 역명이 잘못되었거나 DB에 없음
-        return [
-            (start_station, start_exit, "[오류] 역명 확인 필요", ("", "")),
-            (end_station, "[오류] 역명 확인 필요", end_exit, ("", "")),
-        ]
+        # return [
+        #     (start_station, start_exit, "[오류] 역명 확인 필요", ("", "")),
+        #     (end_station, "[오류] 역명 확인 필요", end_exit, ("", "")),
+        # ]
+        raise RouteBuildError("station nodes not found in graph")
 
     # 3) 최단 경로(환승 가중치=1 최소화)
     best_path: Optional[List[str]] = None
@@ -220,7 +229,9 @@ def get_subway_route(
                 continue
 
     if best_path is None:
-        return [(start_station, start_exit, "[오류] 연결 경로 없음", ("", ""))]
+        # return [(start_station, start_exit, "[오류] 연결 경로 없음", ("", ""))]
+        raise RouteBuildError("no path between stations")
+
 
     path = best_path
 
@@ -447,12 +458,16 @@ def build_guidance_for_segment(
     start_id = get_node_id(df_nodes, station, start_name)
     goal_id  = get_node_id(df_nodes, station, goal_name)
     if start_id is None or goal_id is None:
-        return [f"[{station}] 안내 실패: 노드 식별 불가 (start='{start_name}', goal='{goal_name}')"]
-
+        # return [f"[{station}] 안내 실패: 노드 식별 불가 (start='{start_name}', goal='{goal_name}')"]
+        raise GuidanceBuildError(
+            f"node not found for station={station}, start={start_name}, goal={goal_name}"
+        )
     node_path = bfs_path_node_ids(df_edges_sub, start_id, goal_id)
     if node_path is None:
-        return [f"[{station}] 안내 실패: 경로 없음 (start='{start_name}', goal='{goal_name}')"]
-
+        # return [f"[{station}] 안내 실패: 경로 없음 (start='{start_name}', goal='{goal_name}')"]
+        raise GuidanceBuildError(
+            f"no bfs path for station={station}, start={start_name}, goal={goal_name}"
+        )
     edges_path = to_edge_rows(df_edges_sub, node_path)
 
     steps: List[str] = []

--- a/apps/journeys/views.py
+++ b/apps/journeys/views.py
@@ -26,6 +26,8 @@ from apps.journeys.services.guide import (
     load_graph_from_db,
     get_subway_route,
     build_full_guidance,
+    RouteBuildError, 
+    GuidanceBuildError,
 )
 
 from apps.journeys.services.services import validate_stations
@@ -169,10 +171,6 @@ def route(request):
                 end_exit=end_exit,
             )
 
-            if not short_path_list:
-                messages.error(request, "경로를 찾지 못했습니다. 역 이름을 확인해 주세요.")
-                return redirect("journeys:route")
-
             df_nodes, df_edges = load_graph_from_db()
             steps = build_full_guidance(df_nodes, df_edges, short_path_list)
             if not isinstance(steps, list):
@@ -220,8 +218,21 @@ def route(request):
             )
             return redirect("journeys:route")
 
-        except Exception as e:
-            messages.error(request, f"경로 생성 중 오류: {e}")
+        # 👉 그래프/경로 관련 실패: 사용자에게는 깔끔한 한 줄만
+        except (RouteBuildError, GuidanceBuildError):
+            messages.error(
+                request,
+                "지하철 경로를 만들지 못했어요. "
+                "잠시 후 다시 시도하거나, 출발역·도착역/출구를 바꿔서 다시 시도해 주세요."
+            )
+            return redirect("journeys:route")
+        
+        # 👉 진짜 예기치 못한 오류: 내부 내용(e)은 노출 안 함
+        except Exception:
+            messages.error(
+                request,
+                "일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요."
+            )
             return redirect("journeys:route")
 
     # GET: optional fresh start, then render form/guide depending on session


### PR DESCRIPTION
- apps.journeys.services.guide에 RouteBuildError, GuidanceBuildError 예외 클래스 추가
- get_subway_route/build_guidance_for_segment에서 에러 문장 반환 대신 예외 발생하도록 변경
- build_full_guidance 결과 steps 내 에러 문장 제거
- route 뷰에서 관련 예외는 사용자용 단일 메시지로 처리
- 기타 Exception도 내부 메시지 노출 없이 일반 안내만 표시