### PR TITLE
Feat/route guidance design

### DIFF
--- a/apps/journeys/views.py
+++ b/apps/journeys/views.py
@@ -3,6 +3,7 @@ from django.views.decorators.http import require_http_methods
 from django.contrib import messages
 from django.utils import timezone
 import uuid
+import re
 
 from rest_framework import generics
 from .models import FacilityLoc
@@ -35,6 +36,34 @@ from apps.journeys.services.services import validate_stations
 SESSION_KEY = "journey"
 
 # ------------------ 함수 정의 PART ------------------
+
+def _extract_line_from_direction(direction_str):
+    """
+    방면 문자열에서 호선 정보 추출
+    예: '2호선 충정로 방면 승강장' -> '2호선'
+        '수인분당선 죽전 방면 승강장' -> '수인분당'
+    """
+    if not direction_str:
+        return ""
+
+    # 정규식으로 호선 추출 (숫자호선, 특수노선 등)
+    patterns = [
+        r'^(\d+호선)',           # 1호선, 2호선 등
+        r'^(수인분당)',
+        r'^(신분당선)',
+        r'^(경의중앙)',
+        r'^(공항철도)',
+        r'^(우이신설)',
+        r'^(경춘)',
+    ]
+
+    for pattern in patterns:
+        match = re.match(pattern, direction_str)
+        if match:
+            return match.group(1)
+
+    return ""
+
 
 def _init_session(
     request,
@@ -170,12 +199,39 @@ def route(request):
             if not isinstance(steps, list):
                 steps = list(steps)
 
-            # 🔹 라인/환승 정보는 지금 구조상 3-튜플만 있어서
-            #    별도 메타 없이 기본값으로 둔다 (UI에서 선택적으로 사용)
+            # 6) short_path_list에서 호선 및 환승역 정보 추출
+            # short_path_list 구조: [(역명, 방면1, 방면2), ...]
+            # - 첫 번째: (출발역, 출구, "호선 방면")
+            # - 중간: (환승역, "이전호선 방면", "다음호선 방면")
+            # - 마지막: (도착역, "호선 방면", 출구)
+
             start_line = ""
             end_line = ""
             transfer_stations = []
             transfer_lines = {}
+
+            if short_path_list:
+                # 출발역 호선 추출 (첫 번째 튜플의 3번째 요소에서)
+                if len(short_path_list) > 0 and len(short_path_list[0]) >= 3:
+                    start_line = _extract_line_from_direction(short_path_list[0][2])
+
+                # 도착역 호선 추출 (마지막 튜플의 2번째 요소에서)
+                if len(short_path_list) > 0 and len(short_path_list[-1]) >= 2:
+                    end_line = _extract_line_from_direction(short_path_list[-1][1])
+
+                # 환승역 추출 (첫 번째와 마지막을 제외한 중간 역들)
+                if len(short_path_list) > 2:
+                    for i in range(1, len(short_path_list) - 1):
+                        node = short_path_list[i]
+                        if len(node) >= 3:
+                            station_name = node[0]
+                            # 중간 역의 경우, 3번째 요소(다음 호선 방면)를 환승역의 호선으로 사용
+                            next_line = _extract_line_from_direction(node[2])
+
+                            # 중복 방지: 같은 역이 여러 번 나올 수 있음
+                            if station_name not in transfer_stations:
+                                transfer_stations.append(station_name)
+                                transfer_lines[station_name] = next_line
 
             _init_session(
                 request,

--- a/static/css/route.css
+++ b/static/css/route.css
@@ -373,7 +373,7 @@ body {
     width: 40px;
     height: 40px;
     color: #333;
-    margin-bottom: 16px;
+    margin-bottom: 32px;
 }
 
 /* 에스컬레이터 PNG 아이콘 전용 클래스 */

--- a/static/js/route.js
+++ b/static/js/route.js
@@ -601,10 +601,10 @@ function initializeInstructionIcon() {
     iconElement.className = '';
 
     // 텍스트 내용에 따라 아이콘 설정
-    if (text.includes('에스컬레이터')) {
-        iconElement.className = 'icon-escalator-custom';
-    } else if (text.includes('승차')) {
+    if (text.includes('승차')) {
         iconElement.className = 'fas fa-subway';
+    } else if (text.includes('에스컬레이터')) {
+        iconElement.className = 'icon-escalator-custom';
     } else if (text.includes('엘리베이터')) {
         iconElement.className = 'fas fa-wheelchair';
     } else if (text.includes('계단') || text.includes('도보')) {


### PR DESCRIPTION
경로 안내 로직을 수정하면서 화면 출력 상에서 발생한 오류를 해결했습니다.

1. 경로 안내 텍스트에 '승차'와 '에스컬레이터'가 모두 포함되는 경우, '승차'를 최우선으로 아이콘을 정함.
2. 3-튜플 경로 구조에서 호선 정보를 추출하여 프로그레스바에 반영함.